### PR TITLE
Make C++ standard configurable, with default to C++14

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,8 +21,10 @@
 # CMAKE_BUILD_TYPE   Do you want debug symbols?
 # CMAKE_BINARY_DIR   Where we are building (can also be specified with -B flag)
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.1.3)
 project(LibTaskForce LANGUAGES CXX)
+set(CMAKE_CXX_EXTENSIONS False CACHE BOOL "Enable/Disable compiler-specific C++ extensions")
+set(CMAKE_CXX_STANDARD 14 CACHE STRING "Which C++ standard to use")
 include(ExternalProject)
 
 #Add our special find cmake macros
@@ -31,8 +33,14 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules/")
 find_package(MPI REQUIRED)
 find_package(TBB REQUIRED)
 
+# CMake doesn't support Intel CXX standard until cmake 3.6
+if("${CMAKE_CXX_COMPILER_ID}" MATCHES "Intel")
+  if("${CMAKE_VERSION}" VERSION_LESS "3.6")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++${CMAKE_CXX_STANDARD}")
+  endif()
+endif()
+
 #Sets some extra debug flags
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -fPIC")
 string(TOLOWER "${CMAKE_BUILD_TYPE}" BUILD_TYPE_LOWER) 
 if(BUILD_TYPE_LOWER STREQUAL "debug")
    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -pedantic -Wfloat-equal -Wshadow -Wconversion")
@@ -55,6 +63,8 @@ ExternalProject_Add(libtaskforce_core
               -DLTF_ROOT_DIR=${LTF_ROOT_DIR}
    CMAKE_CACHE_ARGS -DCMAKE_PREFIX_PATH:STRING=${CMAKE_PREFIX_PATH}
                     -DCMAKE_MODULE_PATH:STRING=${CMAKE_MODULE_PATH}
+                    -DCMAKE_CXX_STANDARD:STRING=${CMAKE_CXX_STANDARD}
+                    -DCMAKE_CXX_EXTENSIONS:BOOL=${CMAKE_CXX_EXTENSIONS}
    BUILD_ALWAYS 1
    INSTALL_COMMAND ${CMAKE_MAKE_PROGRAM} install DESTDIR=${CMAKE_BINARY_DIR}/stage
 )

--- a/LibTaskForce/libtaskforceConfig.cmake.in
+++ b/LibTaskForce/libtaskforceConfig.cmake.in
@@ -31,9 +31,6 @@ find_path(LIBTASKFORCE_INCLUDE_DIR
 # Create the target to link against
 add_library(libtaskforce INTERFACE)
 
-# Required options
-target_compile_options(libtaskforce INTERFACE "-std=c++11")
-
 
 #######################################
 # Add the various include directories

--- a/external/cereal/cereal-source/CMakeLists.txt
+++ b/external/cereal/cereal-source/CMakeLists.txt
@@ -4,7 +4,7 @@ project (cereal)
 
 option(SKIP_PORTABILITY_TEST "Skip portability tests" OFF)
 
-set(CMAKE_CXX_FLAGS "-std=c++11 -Wall -Werror -g -Wextra -Wshadow -pedantic ${CMAKE_CXX_FLAGS}")
+set(CMAKE_CXX_FLAGS "-Wall -Werror -g -Wextra -Wshadow -pedantic ${CMAKE_CXX_FLAGS}")
 
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include 
         DESTINATION ${CMAKE_INSTALL_PREFIX}/cereal)

--- a/external/cereal/cereal-source/cerealConfig.cmake.in
+++ b/external/cereal/cereal-source/cerealConfig.cmake.in
@@ -4,6 +4,5 @@ find_path(CEREAL_INCLUDE_DIR
           NO_DEFAULT_PATH
 )
 add_library(cereal INTERFACE)
-target_compile_options(cereal INTERFACE "-std=c++11")
 target_include_directories(cereal INTERFACE ${CEREAL_INCLUDE_DIR})
 set(CEREAL_INCLUDE_DIRS ${CEREAL_INCLUDE_DIR})


### PR DESCRIPTION
I don't know if we have specific CMake version in mind. According to somewhere on the CMake website, CMake 3.1.3 was released Feb 2015